### PR TITLE
feat(colormode): add dark theme initial support

### DIFF
--- a/front/.eslintrc
+++ b/front/.eslintrc
@@ -24,6 +24,6 @@
     "@typescript-eslint/no-use-before-define": 0,
     "@typescript-eslint/camelcase": 0,
     "react-hooks/exhaustive-deps": 0,
-    "arrow-parens": ["warning", "as-needed"]
+    "arrow-parens": ["warn", "as-needed"]
   }
 }

--- a/front/src/components/header/Header.tsx
+++ b/front/src/components/header/Header.tsx
@@ -12,6 +12,7 @@ import {
   MenuItem,
   MenuGroup,
   Text,
+  useColorMode,
 } from '@chakra-ui/core';
 import { FaUser } from 'react-icons/fa';
 import { IoMdNotifications } from 'react-icons/io';
@@ -21,6 +22,7 @@ import { setIsLoggedOutAction } from 'store/user/actions';
 import LoginButton from './subcomponents/LoginButton';
 import SignUpButton from './subcomponents/SignUpButton';
 import LogoutButton from './subcomponents/LogoutButton';
+import ToggleColorModeButton from './subcomponents/ToggleColorModeButton';
 import logo from '../../images/logo.svg';
 
 interface StateProps {
@@ -61,12 +63,15 @@ const Header = ({ isLoggedIn, setIsLoggedOut }: Props) => {
   const wrapperRef = useRef(null);
   const { isOpen, closeHeader, toggleIsOpen } = useHeaderManager(wrapperRef);
   const activeRoute = useLocation().pathname;
+  const { colorMode } = useColorMode();
 
   const onLogout = () => {
     localStorage.removeItem('jwt');
     closeHeader();
     setIsLoggedOut();
   };
+
+  console.log('colorMode', colorMode);
 
   const NavLink = ({
     isActiveRoute,
@@ -82,8 +87,8 @@ const Header = ({ isLoggedIn, setIsLoggedOut }: Props) => {
     <Link onClick={closeHeader} to={linkTo}>
       <Text
         borderBottom={isActiveRoute ? '2px solid' : ''}
-        borderColor={isActiveRoute ? 'secondary' : ''}
-        color={isActiveRoute ? 'secondary' : 'primary'}
+        borderColor={isActiveRoute ? `mode.${colorMode}.secondary` : ''}
+        color={isActiveRoute ? `mode.${colorMode}.secondary` : `mode.${colorMode}.primary`}
         cursor="pointer"
         display="block"
         fontSize="1.1rem"
@@ -103,8 +108,6 @@ const Header = ({ isLoggedIn, setIsLoggedOut }: Props) => {
       <Flex
         align="center"
         as="nav"
-        bg="white"
-        color="black"
         justify="space-between"
         padding="10px 1.6rem 5px"
         ref={wrapperRef}
@@ -180,6 +183,7 @@ const Header = ({ isLoggedIn, setIsLoggedOut }: Props) => {
             <>
               <SignUpButton closeHeader={closeHeader} />
               <LoginButton closeHeader={closeHeader} />
+              <ToggleColorModeButton />
             </>
           )}
         </Box>

--- a/front/src/components/header/Header.tsx
+++ b/front/src/components/header/Header.tsx
@@ -71,8 +71,6 @@ const Header = ({ isLoggedIn, setIsLoggedOut }: Props) => {
     setIsLoggedOut();
   };
 
-  console.log('colorMode', colorMode);
-
   const NavLink = ({
     isActiveRoute,
     linkTo,

--- a/front/src/components/header/subcomponents/ToggleColorModeButton.tsx
+++ b/front/src/components/header/subcomponents/ToggleColorModeButton.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { IconButton, useColorMode } from '@chakra-ui/core';
+
+const ToggleColorModeButton = () => {
+  const { colorMode, toggleColorMode } = useColorMode();
+
+  return (
+    <IconButton
+      aria-label="toggle color mode"
+      ml=" 12px"
+      onClick={toggleColorMode}
+      icon={colorMode === 'light' ? 'sun' : 'moon'}
+    />
+  );
+};
+
+export default ToggleColorModeButton;

--- a/front/src/components/header/subcomponents/ToggleColorModeButton.tsx
+++ b/front/src/components/header/subcomponents/ToggleColorModeButton.tsx
@@ -9,7 +9,7 @@ const ToggleColorModeButton = () => {
       aria-label="toggle color mode"
       ml=" 12px"
       onClick={toggleColorMode}
-      icon={colorMode === 'light' ? 'sun' : 'moon'}
+      icon={colorMode === 'light' ? 'moon' : 'sun'}
     />
   );
 };

--- a/front/src/components/header/subcomponents/ToggleColorModeButton.tsx
+++ b/front/src/components/header/subcomponents/ToggleColorModeButton.tsx
@@ -7,9 +7,9 @@ const ToggleColorModeButton = () => {
   return (
     <IconButton
       aria-label="toggle color mode"
+      icon={colorMode === 'light' ? 'moon' : 'sun'}
       ml=" 12px"
       onClick={toggleColorMode}
-      icon={colorMode === 'light' ? 'moon' : 'sun'}
     />
   );
 };

--- a/front/src/index.tsx
+++ b/front/src/index.tsx
@@ -3,7 +3,7 @@ import { Provider } from 'react-redux';
 import { PersistGate } from 'redux-persist/integration/react';
 import ReactDOM from 'react-dom';
 import configureStore from 'store';
-import { CSSReset, ThemeProvider } from '@chakra-ui/core';
+import { CSSReset, ThemeProvider, ColorModeProvider } from '@chakra-ui/core';
 import App from 'components/App';
 import theme from './theme';
 
@@ -14,8 +14,10 @@ const RenderedApp = (): JSX.Element => (
     <Provider store={store}>
       <PersistGate loading={null} persistor={persistor}>
         <ThemeProvider theme={theme}>
-          <CSSReset />
-          <App />
+          <ColorModeProvider>
+            <CSSReset />
+            <App />
+          </ColorModeProvider>
         </ThemeProvider>
       </PersistGate>
     </Provider>

--- a/front/src/theme.js
+++ b/front/src/theme.js
@@ -7,5 +7,17 @@ export default {
     black: '#333333',
     primary: '#0099DB',
     secondary: '#034A85',
+    mode: {
+      light: {
+        ...defaultTheme.colors,
+        primary: '#0099DB',
+        secondary: '#034A85',
+      },
+      dark: {
+        ...defaultTheme.colors,
+        secondary: '#0099DB',
+        primary: '#034A85',
+      },
+    },
   },
 };


### PR DESCRIPTION
## Changes

Add darkmode support

*Notes*
* Footer is "light" in both modes, the dark didn't quite seem right, but if you want tell me and I will open a new pr.
* Added modes to the colors in the `theme`, right now just switched primary and secondary on dark because of the active tab, this is useful for toggling the color mode in components with explicit colors.

## Screens

Dark
![image](https://user-images.githubusercontent.com/9373787/94880116-060cc500-045a-11eb-8131-d3e5402394e5.png)

Light
![image](https://user-images.githubusercontent.com/9373787/94880101-f9886c80-0459-11eb-885c-ea0263b49436.png)


closes #30

Cheers 👐 