### PR TITLE
feat(eslint): update eslint configs

### DIFF
--- a/api/.eslintrc
+++ b/api/.eslintrc
@@ -19,5 +19,5 @@
     "no-unused-vars": 1,
     "@typescript-eslint/no-explicit-any": 1
   },
-  "exclude": ["node_modules", "dist"]
+  "ignorePatterns": ["node_modules/*", "dist/*"]
 }

--- a/front/.eslintrc
+++ b/front/.eslintrc
@@ -29,5 +29,5 @@
       "shorthandLast": true
     }]
   },
-  "ignorePatterns": ["node_modules/*", "public/*"]
+  "ignorePatterns": ["node_modules/*", "public/*", "build/*"]
 }

--- a/front/.eslintrc
+++ b/front/.eslintrc
@@ -28,5 +28,6 @@
     "react/jsx-sort-props": [2, {
       "shorthandLast": true
     }]
-  }
+  },
+  "ignorePatterns": ["node_modules/*", "public/*"]
 }

--- a/front/.eslintrc
+++ b/front/.eslintrc
@@ -25,7 +25,7 @@
     "@typescript-eslint/camelcase": 0,
     "react-hooks/exhaustive-deps": 0,
     "arrow-parens": ["warn", "as-needed"],
-    "react/jsx-sort-props": [2, {
+    "react/jsx-sort-props": [1, {
       "shorthandLast": true
     }]
   },

--- a/front/package.json
+++ b/front/package.json
@@ -21,7 +21,7 @@
   },
   "scripts": {
     "build": "react-scripts build",
-    "format": "eslint --fix --ext .tsx,.js . && prettier --write \"**/*.{js,scss,json,ts,tsx}\"",
+    "format": "eslint --fix --ext .tsx,.js,.ts . && prettier --write \"**/*.{js,scss,json,ts,tsx}\"",
     "start": "cross-env PORT=4000 react-scripts start"
   },
   "dependencies": {

--- a/front/package.json
+++ b/front/package.json
@@ -21,7 +21,7 @@
   },
   "scripts": {
     "build": "react-scripts build",
-    "format": "prettier --write \"**/*.{js,scss,json,ts,tsx}\"",
+    "format": "eslint --fix --ext .tsx,.js . && prettier --write \"**/*.{js,scss,json,ts,tsx}\"",
     "start": "cross-env PORT=4000 react-scripts start"
   },
   "dependencies": {

--- a/front/src/components/search/subcomponents/SearchInput.tsx
+++ b/front/src/components/search/subcomponents/SearchInput.tsx
@@ -19,7 +19,9 @@ interface Props {
 const SearchInput = ({ handleChange, handleClearInput, inputRef, inputValue }: Props) => (
   <Flex direction="column" justify="center" m="100px auto 25px" w="xs">
     <InputGroup display="flex">
-      <InputLeftElement children={<Icon color="gray.300" name="search-2" />} top="5px" />
+      <InputLeftElement top="5px">
+        <Icon color="gray.300" name="search-2" />
+      </InputLeftElement>
       <Input
         border="2px solid #0099DB"
         borderRadius="5px"
@@ -33,17 +35,15 @@ const SearchInput = ({ handleChange, handleClearInput, inputRef, inputValue }: P
         autoFocus
       />
       {inputValue && (
-        <InputRightElement
-          children={
-            <IconButton
-              aria-label="Clear input"
-              icon="small-close"
-              onClick={handleClearInput}
-              size="sm"
-              variant="ghost"
-            />
-          }
-        />
+        <InputRightElement>
+          <IconButton
+            aria-label="Clear input"
+            icon="small-close"
+            onClick={handleClearInput}
+            size="sm"
+            variant="ghost"
+          />
+        </InputRightElement>
       )}
     </InputGroup>
   </Flex>

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "postinstall": "(cd api && yarn); (cd front && yarn);",
     "serve": "yarn --cwd api serve",
     "serve-stop": "yarn --cwd api serve-stop",
-    "start": "yarn --cwd front start"
+    "start": "yarn --cwd front start",
+    "format-front": "yarn --cwd front format"
   },
   "dependencies": {}
 }


### PR DESCRIPTION
If there's anything to change let me know, @trybick you were right 😄 , the format should be fix now.

https://github.com/trybick/tv-minder/pull/47#issuecomment-703295946

# CHANGES

* Update backend `.eslintrc` to properly ignore `node_modules` and `dist` folders
* Update frontend `.eslintrc` to properly ignore `node_modules` and `public` folders
* Update `format` script on the frontend to run `eslint fix` and `prettier write`
* New `format-front` script on the root to map script format on the front and avoid "navigating directories"
PS - Named it `format-front` assuming that in the future you might have a `format-back` and a `format` (both)

Thanks

Cheers


I started looking at the backend and I found my IDE complaining about this `eslint` configuration:

![image](https://user-images.githubusercontent.com/9373787/95027802-528f1500-0693-11eb-8a64-9c6dadf8f856.png)


