### PR TITLE
Use padding shorthand

### DIFF
--- a/front/src/components/footer/Footer.tsx
+++ b/front/src/components/footer/Footer.tsx
@@ -9,13 +9,13 @@ const Footer = () => {
 
   return (
     <>
-      <Box height="50px" padding=".6rem">
+      <Box height="50px" p=".6rem">
         <Divider />
         <Flex
           alignItems="center"
           fontSize=".85rem"
           justifyContent="space-between"
-          padding={{ xs: '1rem .3rem', sm: '1rem 2rem' }}
+          p={{ xs: '1rem .3rem', sm: '1rem 2rem' }}
         >
           <Box fontWeight="700" height="30px">
             <Link href="https://github.com/trybick/tv-minder" isExternal>

--- a/front/src/components/header/Header.tsx
+++ b/front/src/components/header/Header.tsx
@@ -92,7 +92,7 @@ const Header = ({ isLoggedIn, setIsLoggedOut }: Props) => {
         fontWeight={isActiveRoute ? '600' : '500'}
         mr={1}
         mt={{ base: 4, md: 0 }}
-        padding={{ base: 0, md: '0 12px 5px' }}
+        p={{ base: 0, md: '0 12px 5px' }}
         width={{ base: mobileWidth, md: 'unset' }}
       >
         {text}
@@ -106,7 +106,7 @@ const Header = ({ isLoggedIn, setIsLoggedOut }: Props) => {
         align="center"
         as="nav"
         justify="space-between"
-        padding="10px 1.6rem 5px"
+        p="10px 1.6rem 5px"
         ref={wrapperRef}
         wrap="wrap"
       >
@@ -126,7 +126,7 @@ const Header = ({ isLoggedIn, setIsLoggedOut }: Props) => {
         <Box
           display={{ xs: isOpen ? 'block' : 'none', md: 'flex' }}
           mr="auto"
-          paddingLeft="10px"
+          pl="10px"
           pt="10px"
           width={{ xs: 'full', md: 'auto' }}
         >

--- a/front/src/pages/SearchPage.tsx
+++ b/front/src/pages/SearchPage.tsx
@@ -94,7 +94,7 @@ const SearchPage = ({ saveSearchQuery, savedQueries }: Props) => {
       flex="1"
       margin="50px"
       mb="25px"
-      paddingBottom="20px"
+      pb="20px"
     >
       <SearchInput
         handleChange={handleChange}


### PR DESCRIPTION
Uses padding shorthand for chakra UI. Related to #52. 

<img width="884" alt="image" src="https://user-images.githubusercontent.com/22270042/95030223-3d5abc00-067c-11eb-9d3e-3a1458969dad.png">

After the replacement, I ran the app and everything was working as expected.
