### PR TITLE
fix(footer): align github vertically with baseline of rest of footer text

### DIFF
--- a/front/src/components/footer/Footer.tsx
+++ b/front/src/components/footer/Footer.tsx
@@ -17,9 +17,14 @@ const Footer = () => {
           justifyContent="space-between"
           p={{ xs: '1rem .3rem', sm: '1rem 2rem' }}
         >
-          <Box fontWeight="700" height="30px">
-            <Link href="https://github.com/trybick/tv-minder" isExternal>
-              <Box as={FaGithub} display="inline" mr="4px" size="16px" verticalAlign="sub" />
+          <Box fontWeight="700">
+            <Link
+              alignItems="baseline"
+              display="flex"
+              href="https://github.com/trybick/tv-minder"
+              isExternal
+            >
+              <Box as={FaGithub} display="inline" mr="4px" size="12px" verticalAlign="sub" />
               <Text display="inline">GitHub</Text>
             </Link>
           </Box>


### PR DESCRIPTION
Fixes: https://github.com/trybick/tv-minder/issues/58

Summary:

* Aligned github text vertically
* Shrunk github icon to not exceed height of text


When collapsing the margin, the baseline of the text matches each other
<img width="302" alt=" " src="https://user-images.githubusercontent.com/20917792/95285739-84d57980-082f-11eb-8f95-78fe5d634898.png">
