### PR TITLE
Add loading indicator to Calendar page

### DIFF
--- a/front/src/features/calendar/CalendarLoadingIndicator.tsx
+++ b/front/src/features/calendar/CalendarLoadingIndicator.tsx
@@ -1,0 +1,64 @@
+import { Box, Flex, Icon, Spinner, Text } from '@chakra-ui/react';
+import { useEffect, useState } from 'react';
+import { FiCheckCircle } from 'react-icons/fi';
+
+type CalendarLoadingIndicatorProps = {
+  isLoading: boolean;
+};
+
+const CalendarLoadingIndicator = ({
+  isLoading,
+}: CalendarLoadingIndicatorProps) => {
+  const [showSuccess, setShowSuccess] = useState(false);
+
+  useEffect(() => {
+    if (!isLoading && !showSuccess) {
+      // Show success message when loading completes
+      setShowSuccess(true);
+      const timer = setTimeout(() => {
+        setShowSuccess(false);
+      }, 3000); // Show for 3 seconds only
+
+      return () => clearTimeout(timer);
+    }
+  }, [isLoading, showSuccess]);
+
+  if (!isLoading && !showSuccess) {
+    return null;
+  }
+
+  return (
+    <Box
+      position="fixed"
+      top="70px"
+      right="20px"
+      zIndex={1000}
+      bg={isLoading ? 'blue.50' : 'green.50'}
+      borderRadius="md"
+      boxShadow="md"
+      p={3}
+      border="1px solid"
+      borderColor={isLoading ? 'blue.200' : 'green.200'}
+    >
+      <Flex align="center" gap={2}>
+        {isLoading ? (
+          <>
+            <Spinner size="sm" color="blue.500" />
+            <Text fontSize="sm" fontWeight="medium" color="blue.700">
+              Fetching episodes...
+            </Text>
+          </>
+        ) : (
+          <>
+            <Icon as={FiCheckCircle} color="green.500" boxSize={5} />
+            <Text fontSize="sm" fontWeight="medium" color="green.700">
+              Up to date
+            </Text>
+          </>
+        )}
+      </Flex>
+    </Box>
+  );
+};
+
+export default CalendarLoadingIndicator;

--- a/front/src/features/calendar/CalendarPage.tsx
+++ b/front/src/features/calendar/CalendarPage.tsx
@@ -17,9 +17,13 @@ import { useIsMobile } from '~/hooks/useIsMobile';
 import { useNavigateWithAnimation } from '~/hooks/useNavigateWithAnimation';
 import { useAppDispatch, useAppSelector } from '~/store';
 import { getEpisodesForCalendarAction } from '~/store/tv/actions';
-import { selectCalendarEpisodesForDisplay } from '~/store/tv/selectors';
+import {
+  selectCalendarEpisodesForDisplay,
+  selectIsLoadingCalendarEpisodes,
+} from '~/store/tv/selectors';
 import { selectFollowedShows } from '~/store/user/selectors';
 
+import CalendarLoadingIndicator from './CalendarLoadingIndicator';
 import DesktopCalendarEventPopover from './DesktopCalendarEventPopover';
 import NoFollowedShowsBanner from './NoFollowedShowsBanner';
 
@@ -33,6 +37,9 @@ const CalendarPage = () => {
 
   const followedShows = useAppSelector(selectFollowedShows);
   const calendarEpisodes = useAppSelector(selectCalendarEpisodesForDisplay);
+  const isLoadingCalendarEpisodes = useAppSelector(
+    selectIsLoadingCalendarEpisodes
+  );
 
   useEffect(() => {
     const loadEpisodes = () => {
@@ -122,6 +129,8 @@ const CalendarPage = () => {
   return (
     <>
       <title>Calendar | TV Minder</title>
+
+      <CalendarLoadingIndicator isLoading={isLoadingCalendarEpisodes} />
 
       {!hasEpisodesInCurrentMonth && <NoFollowedShowsBanner />}
 

--- a/front/src/store/tv/actions.ts
+++ b/front/src/store/tv/actions.ts
@@ -14,6 +14,7 @@ import { SavedQuery } from './types';
 export const SET_SEARCH_QUERY = 'SET_SEARCH_QUERY';
 export const SAVE_CALENDAR_EPISODES_CACHE = 'SAVE_CALENDAR_EPISODES_CACHE';
 export const SET_CURRENT_CALENDAR_EPISODES = 'SET_CURRENT_CALENDAR_EPISODES';
+export const SET_IS_LOADING_CALENDAR_EPISODES = 'SET_IS_LOADING_CALENDAR_EPISODES';
 export const SAVE_BASIC_SHOW_INFO_FOR_FOLLOWED_SHOWS =
   'SAVE_BASIC_SHOW_INFO_FOR_FOLLOWED_SHOWS';
 export const SAVE_BASIC_SHOW_INFO_FOR_SHOW = 'SAVE_BASIC_SHOW_INFO_FOR_SHOW';
@@ -33,6 +34,11 @@ export const saveSearchQueryAction =
 
 export const getEpisodesForCalendarAction =
   (): AppThunk => async (dispatch, getState) => {
+    dispatch({
+      type: SET_IS_LOADING_CALENDAR_EPISODES,
+      payload: true,
+    });
+
     const state = getState();
     const { episodeData: storedEpisodeData } = state.tv;
     const userFollowedShowsIds = selectFollowedShows(state);
@@ -69,6 +75,10 @@ export const getEpisodesForCalendarAction =
     dispatch({
       type: SET_CURRENT_CALENDAR_EPISODES,
       payload: combinedEpisodesForDisplay,
+    });
+    dispatch({
+      type: SET_IS_LOADING_CALENDAR_EPISODES,
+      payload: false,
     });
   };
 

--- a/front/src/store/tv/reducers.ts
+++ b/front/src/store/tv/reducers.ts
@@ -10,6 +10,7 @@ import {
   SAVE_TOP_RATED_SHOWS,
   SET_CURRENT_CALENDAR_EPISODES,
   SET_IS_LOADING_BASIC_SHOW_INFO_FOR_SHOW,
+  SET_IS_LOADING_CALENDAR_EPISODES,
   SET_SEARCH_QUERY,
 } from './actions';
 import { SavedQuery } from './types';
@@ -19,6 +20,7 @@ export type TvState = {
   episodeData: Record<number, any>;
   basicShowInfo: Record<number, any>;
   isLoadingBasicShowInfoForShow: boolean;
+  isLoadingCalendarEpisodes: boolean;
   calendarEpisodesForDisplay: CalendarEpisode[];
   popularShows: Record<string, any>[];
   topRatedShows: Record<string, any>[];
@@ -29,6 +31,7 @@ const initialState = {
   episodeData: {},
   basicShowInfo: {},
   isLoadingBasicShowInfoForShow: false,
+  isLoadingCalendarEpisodes: false,
   calendarEpisodesForDisplay: [],
   popularShows: [],
   topRatedShows: [],
@@ -81,6 +84,12 @@ export const tvReducer: Reducer<TvState, Action> = (
       return {
         ...state,
         calendarEpisodesForDisplay: action.payload,
+      };
+    }
+    case SET_IS_LOADING_CALENDAR_EPISODES: {
+      return {
+        ...state,
+        isLoadingCalendarEpisodes: action.payload,
       };
     }
     case SAVE_POPULAR_SHOWS: {

--- a/front/src/store/tv/selectors.ts
+++ b/front/src/store/tv/selectors.ts
@@ -12,6 +12,8 @@ export const selectSavedQueries = (state: AppState) => state.tv.savedQueries;
 export const selectBasicShowInfo = (state: AppState) => state.tv.basicShowInfo;
 export const selectIsLoadingBasicShowInfoForShow = (state: AppState) =>
   state.tv.isLoadingBasicShowInfoForShow;
+export const selectIsLoadingCalendarEpisodes = (state: AppState) =>
+  state.tv.isLoadingCalendarEpisodes;
 export const selectCalendarEpisodesForDisplay = (state: AppState) =>
   state.tv.calendarEpisodesForDisplay;
 export const selectPopularShows = (state: AppState) => state.tv.popularShows;


### PR DESCRIPTION
### Description

This PR resolves issue #166 by adding a visual indicator to the Calendar page that informs the user when episode data is being fetched.

### Changes Made

- **Redux State**: Added `isLoadingCalendarEpisodes` to the `tv` slice to manage the loading state.
- **New Component**: Created `CalendarLoadingIndicator.tsx` which shows a "Fetching episodes..." spinner and an "Up to date" success message.
- **UI Integration**: The indicator is displayed in the top-right corner of the Calendar page and is connected to the Redux store.

### Before 
<img width="2181" height="537" alt="image" src="https://github.com/user-attachments/assets/ffef6dd8-755f-414f-965a-eabcbc70ccfd" />


### After 
<img width="2198" height="566" alt="image" src="https://github.com/user-attachments/assets/f272ac37-957d-4c55-9d4c-cd48656b524a" />


### How to Test

1. Navigate to the Calendar page.
2. Observe the "Fetching episodes..." indicator.
3. Once loaded, confirm that the "Up to date" message appears for 3 seconds.
4. Switch to another browser tab and then return to the TV-Minder tab.
5. Confirm the loading/success cycle repeats.

Closes #166